### PR TITLE
Use `memex>` as the default prompt

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,4 +1,6 @@
-#IO.puts "Executing code in `.iex.exs...`"
+# IO.puts "Executing code in `.iex.exs...`"
+
+IEx.configure(default_prompt: "memex>", continuation_prompt: "...>")
 
 alias Memex.My
 alias Memex.My.Journal


### PR DESCRIPTION
This is just an idea and implementation of using `memex>` as the default
CLI prompt instead of `iex>`.

To me this makes the app feel more tailored to the job of a Memex and
less about Elixir.

![memex_prompt](https://user-images.githubusercontent.com/42816/145123690-31cc7310-680a-4a41-8566-51364d7ae8d9.png)


Love to hear your thoughts!